### PR TITLE
Fixes GPU OOM on OpenPose training

### DIFF
--- a/4_pose_estimation/4-6_OpenPose_training.ipynb
+++ b/4_pose_estimation/4-6_OpenPose_training.ipynb
@@ -289,7 +289,7 @@
     "\n",
     "                    loss = criterion(saved_for_loss, heatmap_target,\n",
     "                                     heat_mask, paf_target, paf_mask)\n",
-    "\n",
+    "                    del saved_for_loss\n",
     "                    # 訓練時はバックプロパゲーション\n",
     "                    if phase == 'train':\n",
     "                        loss.backward()\n",


### PR DESCRIPTION
以下環境にて学習時OOMが出るため、念のためお伝えいたします。
```
$conda list | grep torch
pytorch                   1.2.0           py3.7_cuda10.0.130_cudnn7.6.2_0    pytorch
torchvision               0.4.0                py37_cu100    pytorch
```

```
$ nvidia-smi
Thu Oct  3 14:48:00 2019       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 418.87.00    Driver Version: 418.87.00    CUDA Version: 10.1     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|===============================+======================+======================|
|   0  GeForce GTX 108...  On   | 00000000:01:00.0  On |                  N/A |
| 26%   43C    P8    11W / 250W |     85MiB / 11175MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
|   1  GeForce GTX 108...  On   | 00000000:03:00.0 Off |                  N/A |
| 28%   44C    P8     9W / 250W |  11031MiB / 11178MiB |      0%      Default |
+-------------------------------+----------------------+----------------------+
```