### PR TITLE
Fix: modify the parameters to new style

### DIFF
--- a/1_image_classification/1-1_load_vgg.ipynb
+++ b/1_image_classification/1-1_load_vgg.ipynb
@@ -159,7 +159,7 @@
         "\n",
         "# VGG-16モデルのインスタンスを生成\n",
         "use_pretrained = True  # 学習済みのパラメータを使用\n",
-        "net = models.vgg16(pretrained=use_pretrained)\n",
+        "net = models.vgg16(weights=models.VGG16_Weights.DEFAULT)\n",
         "net.eval()  # 推論モードに設定\n",
         "\n",
         "# モデルのネットワーク構成を出力\n",


### PR DESCRIPTION
The paramter has been changed for loading pretrained models since torchvision V0.13

Original message: 
UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.
UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=VGG16_Weights.IMAGENET1K_V1`. You can also use `weights=VGG16_Weights.DEFAULT` to get the most up-to-date weights.